### PR TITLE
Kalenderwoche im Mailbetreff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 inc/config.php
 .*.swp
+.settings
+.buildpath
+.project

--- a/mail.php
+++ b/mail.php
@@ -64,7 +64,10 @@ if ($preview) {
 
 $mail = wordwrap ($mail, 70);
 
-mail ($_CONFIG['MAIL_RECEIVER'], "Kochliste", $mail, "From: ". $_CONFIG["MAIL_FROM"]);
+$date = new DateTime();
+$subject = "Kochliste KW " . $date->format("W") . " " . $date->format("Y");
+
+mail ($_CONFIG['MAIL_RECEIVER'], $subject, $mail, "From: ". $_CONFIG["MAIL_FROM"]);
 
 print "Gesendet:\n--------------------\n";
 print $mail;


### PR DESCRIPTION
Nachdem u.a. Barbaras Mailclient aus diversen Threads einen riesigen Megathread zusammenklatscht und auch allgemein die Unübersichtlichkeit groß ist, dachte ich, die KW in die Mail betreffzeile zu tun könnte helfen.