### PR TITLE
Feature/add event odd line colors

### DIFF
--- a/base.css
+++ b/base.css
@@ -59,3 +59,8 @@ a {
 label {
   padding-right: 10px;
 }
+
+/* odd-rows coloring for "new event" */
+#f0 .block:nth-child(4n+1) /* 4n since each row is 2 elements */ {
+    background-color: #eee;
+}

--- a/event.php
+++ b/event.php
@@ -32,9 +32,11 @@ $expected_event_id = $r[0] + 1;
 <br>
 
 <div class='block'>
-  <div class='fl'><img src='img/arrow-down.svg' class='icon14_16'>Teilnehmer</div>
-  <div class='fr'>Bezahler<img src='img/arrow-down.svg' class='icon14_16'></div>
-<br>
+    <div class='head'>
+        <div class='fl'><img src='img/arrow-down.svg' class='icon14_16'>Teilnehmer</div>
+        <div class='fr'>Bezahler<img src='img/arrow-down.svg' class='icon14_16'></div>
+    </div>
+    <br>
 
 <?php
 // Get top 3 whoms turn it is


### PR DESCRIPTION
this PR adds odd-line coloring for the "add event" page, preventing errors when selecting payer and +1s.